### PR TITLE
Developer/jokleinf/add archive file support

### DIFF
--- a/DiagnosticsExtension/Controllers/EventsController.cs
+++ b/DiagnosticsExtension/Controllers/EventsController.cs
@@ -23,6 +23,7 @@ namespace DiagnosticsExtension.Controllers
     public class EventsController : ApiController
     {
         public string EventLogFile = Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Logfiles" , "eventlog.xml");
+        public string EventLogArchiveFile = Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Logfiles", "eventlog.prev.xml");
         public string EventLogFilePath = Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Logfiles");
 
         public async Task<HttpResponseMessage> Get()
@@ -30,7 +31,7 @@ namespace DiagnosticsExtension.Controllers
             var events = new List<ServerSideEvent>();
             try
             {
-                events = await EventLogParser.GetEvents(EventLogFile);
+                events = await EventLogParser.GetEvents(EventLogFile, EventLogArchiveFile);
                 return Request.CreateResponse(HttpStatusCode.OK, events);
             }
             catch (XmlException)

--- a/DiagnosticsExtension/Parsers/EventLogParser.cs
+++ b/DiagnosticsExtension/Parsers/EventLogParser.cs
@@ -208,7 +208,7 @@ namespace DiagnosticsExtension
 
             InitializeKnownResourceTypes();
 
-            if (!string.IsNullOrEmpty(eventLogArchivePath))
+            if (!string.IsNullOrEmpty(eventLogArchivePath) && File.Exists(eventLogArchivePath))
             {
                 string archiveText = string.Empty;
                 XmlDocument archiveDom = null;

--- a/DiagnosticsExtension/Parsers/EventLogParser.cs
+++ b/DiagnosticsExtension/Parsers/EventLogParser.cs
@@ -196,9 +196,10 @@ namespace DiagnosticsExtension
             return returnValue;
         }
 
-        public static async Task<List<ServerSideEvent>> GetEvents(string eventLogPath)
+        public static async Task<List<ServerSideEvent>> GetEvents(string eventLogPath, string eventLogArchivePath = null)
         {
             var events = new List<ServerSideEvent>();
+            XmlNodeList archiveXmlList = null;
 
             if (!File.Exists(eventLogPath))
             {
@@ -206,6 +207,24 @@ namespace DiagnosticsExtension
             }
 
             InitializeKnownResourceTypes();
+
+            if (!string.IsNullOrEmpty(eventLogArchivePath))
+            {
+                string archiveText = string.Empty;
+                XmlDocument archiveDom = null;
+
+                await RetryHelper.RetryOnExceptionAsync<IOException>(10, TimeSpan.FromSeconds(1), async () =>
+                {
+                    archiveText = await FileSystemHelpers.ReadAllTextFromFileAsync(eventLogArchivePath);
+                });
+
+                if (!string.IsNullOrWhiteSpace(archiveText))
+                {
+                    archiveDom = new XmlDocument();
+                    archiveDom.LoadXml(archiveText);
+                    archiveXmlList = archiveDom.SelectNodes("/Events/Event");
+                }
+            }
 
             string fileText = string.Empty;
             await RetryHelper.RetryOnExceptionAsync<IOException>(10, TimeSpan.FromSeconds(1), async() => 
@@ -218,10 +237,19 @@ namespace DiagnosticsExtension
                 return events;
             }
 
-            XmlDocument dom = new XmlDocument();
-            dom.LoadXml(fileText);
+            XmlDocument currentDom = new XmlDocument();
+            currentDom.LoadXml(fileText);
 
-            XmlNodeList xmlList = dom.SelectNodes("/Events/Event");
+            XmlNodeList currentXmlList = currentDom.SelectNodes("/Events/Event");
+            List<XmlNode> xmlList;
+            if (archiveXmlList == null || archiveXmlList.Count == 0)
+            {
+                xmlList = new List<XmlNode>(currentXmlList.Cast<XmlNode>());
+            }
+            else
+            {
+                xmlList = new List<XmlNode>(archiveXmlList.Cast<XmlNode>().Concat(currentXmlList.Cast<XmlNode>()));
+            }
 
             for (int i = (xmlList.Count - 1); i >= 0; i--)
             {


### PR DESCRIPTION
Antares is updating the event log generation code to be more efficient by adding an archive file, eventlog.prev.xml, that old events get rolled over to instead of getting deleted immediately every time a new event comes in. Therefore, DaaS should scan for this file and add events from it to those from the primary event log file.