### PR TITLE
Creating the ConnectionStringValidationController 

### DIFF
--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -1,0 +1,86 @@
+//-----------------------------------------------------------------------
+// <copyright file="UdpEchoTestController.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using DiagnosticsExtension.Models.ConnectionStringValidator;
+
+namespace DiagnosticsExtension.Controllers
+{
+    /// <summary>
+    /// Worker instances are running an udp echo server on port 30000. This controller is for checking the connection between target 
+    /// worker instance by pinging and checking the echoed result.
+    /// </summary>
+    [RoutePrefix("api/connectionstringvalidation")]
+    public class ConnectionStringValidationController : ApiController
+    {
+        [HttpGet]
+        [Route("test")]
+        public async Task<HttpResponseMessage> Test(string connStr, int? typeId = null)
+        {
+            var typeValidatorMap = new IConnectionStringValidator[]
+            {
+                new SqlServerValidator()
+            }.ToDictionary(v => v.Type, v => v);
+
+            if (typeId != null)
+            {
+                var enumType = (ConnectionStringType)typeId.Value;
+                if (typeValidatorMap.ContainsKey(enumType))
+                {
+                    var result = await typeValidatorMap[enumType].Test(connStr);
+                    return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                }
+                else
+                {
+                    return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"No supported validator found for typeId={typeId.Value}");
+                }
+            }
+            else
+            {
+                foreach (var p in typeValidatorMap)
+                {
+                    try
+                    {
+                        if (p.Value.IsValid(connStr))
+                        {
+                            var result = await p.Value.Test(connStr);
+                            return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                        }
+                    }
+                    catch (Exception e)
+                    { 
+                    }
+                }
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"No supported validator found for provided connection string");
+            }
+        }
+
+        [HttpGet]
+        [Route("testappsetting")]
+        public async Task<HttpResponseMessage> TestAppSetting(string appSettingName, int? typeId = null)
+        {
+            var envDict = Environment.GetEnvironmentVariables();
+            if (envDict.Contains(appSettingName))
+            {
+                var connectionString = (string)envDict[appSettingName];
+                return await Test(connectionString, typeId);
+            }
+            else
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"AppSetting {appSettingName} not found");
+            }
+        }
+    }
+}

--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -26,8 +26,8 @@ namespace DiagnosticsExtension.Controllers
     public class ConnectionStringValidationController : ApiController
     {
         [HttpGet]
-        [Route("test")]
-        public async Task<HttpResponseMessage> Test(string connStr, int? typeId = null)
+        [Route("validate")]
+        public async Task<HttpResponseMessage> Validate(string connStr, int? typeId = null)
         {
             // register all validators here
             var typeValidatorMap = new IConnectionStringValidator[]
@@ -71,14 +71,14 @@ namespace DiagnosticsExtension.Controllers
         }
 
         [HttpGet]
-        [Route("testappsetting")]
-        public async Task<HttpResponseMessage> TestAppSetting(string appSettingName, int? typeId = null)
+        [Route("validateappsetting")]
+        public async Task<HttpResponseMessage> ValidateAppSetting(string appSettingName, int? typeId = null)
         {
             var envDict = Environment.GetEnvironmentVariables();
             if (envDict.Contains(appSettingName))
             {
                 var connectionString = (string)envDict[appSettingName];
-                return await Test(connectionString, typeId);
+                return await Validate(connectionString, typeId);
             }
             else
             {

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Controllers\CpuMonitoringController.cs" />
     <Compile Include="Controllers\CrashMonitoringController.cs" />
     <Compile Include="Controllers\DaasAdministerController.cs" />
+    <Compile Include="Controllers\ConnectionStringValidationController.cs" />
     <Compile Include="Controllers\UdpEchoTestController.cs" />
     <Compile Include="Controllers\DatabaseTestController.cs" />
     <Compile Include="Controllers\DownloadFileController.cs" />
@@ -213,6 +214,10 @@
     <Compile Include="Controllers\SessionsController.cs" />
     <Compile Include="Controllers\StdoutLogsController.cs" />
     <Compile Include="LoggingHandler.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />
     <Compile Include="Models\LogsSettings.cs" />
     <Compile Include="Models\MsiValidatorModels.cs" />
     <Compile Include="Models\SasUriResponse.cs" />

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public enum ConnectionStringType
+    {
+        SqlServer,
+        RedisCache,
+        StorageAccount,
+        Http
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
@@ -7,9 +7,17 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 {
     public enum ConnectionStringType
     {
+        // Jeff
         SqlServer,
+        MySql,
+        KeyVault,
+        Http,
         RedisCache,
+
+        // Sid
         StorageAccount,
-        Http
+        ServiceBus,
+        EventHubs,
+        CosmosDB
     }
 }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+
+    public class ConnectionStringValidationResult
+    {
+        public enum ResultStatus
+        {
+            Succeeded,
+            EndpointNotFound,
+            ConnectionFailed,
+            AuthFailed,
+            MsiFailed,
+            UnknownError
+        }
+
+        public ResultStatus Status;
+        public Exception Exception;
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -10,11 +10,11 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
     {
         public enum ResultStatus
         {
-            Succeeded,
+            Success,
+            AuthFailure,
+            ConnectionFailure,
             EndpointNotFound,
-            ConnectionFailed,
-            AuthFailed,
-            MsiFailed,
+            MsiFailure,
             UnknownError
         }
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    interface IConnectionStringValidator
+    {
+        // verify provided string is a valid connection string that can be tested by the validator
+        bool IsValid(string connStr);
+
+        Task<ConnectionStringValidationResult> Test(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
+
+        string ProviderName { get; }
+
+        ConnectionStringType Type { get; }
+
+
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -11,7 +11,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
         // verify provided string is a valid connection string that can be tested by the validator
         bool IsValid(string connStr);
 
-        Task<ConnectionStringValidationResult> Test(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
+        Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
 
         string ProviderName { get; }
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class SqlServerValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "System.Data.SqlClient";
+
+        public ConnectionStringType Type => ConnectionStringType.SqlServer;
+
+        public bool IsValid(string connStr)
+        {
+            throw new NotImplementedException();
+        }
+
+        async public Task<ConnectionStringValidationResult> Test(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult();
+            using (SqlConnection conn = new SqlConnection())
+            {
+                try
+                {
+                    conn.ConnectionString = connStr;
+                    SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(conn.ConnectionString);
+                    string userId = builder.UserID;
+                    string password = builder.Password;
+
+                    if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(password))
+                    {
+                        MsiValidator msi = new MsiValidator();
+
+                        if (msi.IsEnabled())
+                        {
+                            var input = new MsiValidatorInput(ResourceType.Sql, clientId);
+                            bool hasConnectivityWithAzureAd = await msi.GetTokenAsync(input);
+
+                            if (hasConnectivityWithAzureAd)
+                            {
+                                conn.AccessToken = msi.Result.GetTokenTestResult.TokenInformation.AccessToken;
+                            }
+                            else
+                            {
+                                var adalError = msi.Result.GetTokenTestResult.ErrorDetails;
+                                var e = new Exception(adalError.Message);
+                                e.Data["AdalError"] = adalError;
+                                response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailed;
+                                response.Exception = e;
+                                return response;
+                            }
+                        }
+                    }
+
+
+                    await conn.OpenAsync();
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Succeeded;
+                }
+                catch (Exception e)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                    response.Exception = e;
+                }
+
+                return response;
+            }
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -18,7 +18,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             throw new NotImplementedException();
         }
 
-        async public Task<ConnectionStringValidationResult> Test(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult();
             using (SqlConnection conn = new SqlConnection())
@@ -48,7 +48,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                                 var adalError = msi.Result.GetTokenTestResult.ErrorDetails;
                                 var e = new Exception(adalError.Message);
                                 e.Data["AdalError"] = adalError;
-                                response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailed;
+                                response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailure;
                                 response.Exception = e;
                                 return response;
                             }
@@ -57,7 +57,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
 
                     await conn.OpenAsync();
-                    response.Status = ConnectionStringValidationResult.ResultStatus.Succeeded;
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Adding a new `ConnectionStringValidationController` to DaaS extension to allow Network Troubleshooter to test any arbitrary connection string

In this PR following changes are included
1. a new `ConnectionStringValidationController` include two sub routes `test` and `testappsetting`
2. an `IConnectionStringValidator` interface which abstracts the connection validator and `SqlServerValidator`, an implementation of the interface 
3. a `ConnectionStringValidationResult` class, the output of a validator