### PR TITLE
Adding more validators to the new connection string validator endpoint

### DIFF
--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -38,8 +38,8 @@ namespace DiagnosticsExtension.Controllers
                 new MySqlValidator(),
                 new KeyVaultValidator(),
                 new StorageValidator(),
-                //new ServiceBusValidator(),
-                //new EventHubsValidator(),
+                new ServiceBusValidator(),
+                new EventHubsValidator(),
                 new HttpValidator()
             };
             typeValidatorMap = validators.ToDictionary(v => v.Type, v => v);

--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -37,6 +37,9 @@ namespace DiagnosticsExtension.Controllers
                 new SqlServerValidator(),
                 new MySqlValidator(),
                 new KeyVaultValidator(),
+                new StorageValidator(),
+                //new ServiceBusValidator(),
+                //new EventHubsValidator(),
                 new HttpValidator()
             };
             typeValidatorMap = validators.ToDictionary(v => v.Type, v => v);
@@ -44,42 +47,32 @@ namespace DiagnosticsExtension.Controllers
 
         [HttpGet]
         [Route("validate")]
-        public async Task<HttpResponseMessage> Validate(string connStr, int? typeId = null)
+        public async Task<HttpResponseMessage> Validate(string connStr, string type)
         {
-            
-
-            if (typeId != null)
+            bool success = Enum.TryParse(type, out ConnectionStringType csType);
+            if (success)
             {
-                var enumType = (ConnectionStringType)typeId.Value;
-                if (typeValidatorMap.ContainsKey(enumType))
-                {
-                    var result = await typeValidatorMap[enumType].Validate(connStr);
-                    return Request.CreateResponse(HttpStatusCode.OK, result);
-                }
-                else
-                {
-                    return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"No supported validator found for typeId={typeId.Value}");
-                }
+                return await Validate(connStr, (int)csType);
             }
             else
             {
-                var exceptions = new List<Exception>();
-                foreach (var validator in validators)
-                {
-                    try
-                    {
-                        if (validator.IsValid(connStr))
-                        {
-                            var result = await validator.Validate(connStr);
-                            return Request.CreateResponse(HttpStatusCode.OK, result);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        exceptions.Add(e);
-                    }
-                }
-                return Request.CreateErrorResponse(HttpStatusCode.NotFound, new AggregateException($"No supported validator found for provided connection string", exceptions));
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, $"type '{type}' is not supported");
+            }
+        }
+
+        [HttpGet]
+        [Route("validate")]
+        public async Task<HttpResponseMessage> Validate(string connStr, int typeId)
+        {
+            var enumType = (ConnectionStringType)typeId;
+            if (typeValidatorMap.ContainsKey(enumType))
+            {
+                var result = await typeValidatorMap[enumType].Validate(connStr);
+                return Request.CreateResponse(HttpStatusCode.OK, result);
+            }
+            else
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"No supported validator found for typeId={typeId}");
             }
         }
 
@@ -101,6 +94,10 @@ namespace DiagnosticsExtension.Controllers
                 {
                     throw new Exception("Null or empty connection string");
                 }
+                if (typeId == null && type == null)
+                {
+                    throw new Exception("Either typeId or type are required");
+                }
             }
             catch (Exception e)
             {
@@ -115,17 +112,17 @@ namespace DiagnosticsExtension.Controllers
                 }
                 else
                 {
-                    return Request.CreateErrorResponse(HttpStatusCode.BadRequest, $"type {type} is not supported");
+                    return Request.CreateErrorResponse(HttpStatusCode.BadRequest, $"type '{type}' is not supported");
                 }
             }
 
-            var result = await Validate(connStr, typeId);
+            var result = await Validate(connStr, typeId.Value);
             return result;
         }
 
         [HttpGet]
         [Route("validateappsetting")]
-        public async Task<HttpResponseMessage> ValidateAppSetting(string appSettingName, int? typeId = null)
+        public async Task<HttpResponseMessage> ValidateAppSetting(string appSettingName, int typeId)
         {
             var envDict = Environment.GetEnvironmentVariables();
             if (envDict.Contains(appSettingName))

--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -67,7 +67,7 @@ namespace DiagnosticsExtension.Controllers
             var enumType = (ConnectionStringType)typeId;
             if (typeValidatorMap.ContainsKey(enumType))
             {
-                var result = await typeValidatorMap[enumType].Validate(connStr);
+                var result = await typeValidatorMap[enumType].ValidateAsync(connStr);
                 return Request.CreateResponse(HttpStatusCode.OK, result);
             }
             else

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -293,11 +293,13 @@
     <Compile Include="LoggingHandler.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\EventHubsValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\Exceptions\EmptyConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\Exceptions\MalformedConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\HttpValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\KeyVaultValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ServiceBusValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\StorageValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\MySqlValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -61,8 +61,23 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Amqp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Amqp.2.4.9\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.EventHubs, Version=3.0.0.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.EventHubs.3.0.0\lib\net461\Microsoft.Azure.EventHubs.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.EventHubs.Processor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.EventHubs.Processor.3.0.0\lib\net461\Microsoft.Azure.EventHubs.Processor.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.ServiceBus, Version=4.2.1.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.ServiceBus.4.2.1\lib\netstandard2.0\Microsoft.Azure.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Services.AppAuthentication, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\lib\net452\Microsoft.Azure.Services.AppAuthentication.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -74,11 +89,23 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.5.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.4.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.4.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.4.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.Storage.9.3.3\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
@@ -96,14 +123,30 @@
       <HintPath>..\packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Data.SqlClient, Version=4.6.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SqlClient.4.8.2\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.4.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
@@ -113,10 +156,45 @@
     <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.WebSockets, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.4.0.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.WebSockets.Client, Version=4.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.Client.4.0.2\lib\net46\System.Net.WebSockets.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.TypeExtensions.4.5.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.8.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
@@ -167,12 +245,11 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
@@ -366,6 +443,9 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
@@ -376,7 +456,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
+          <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>53018</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
@@ -386,10 +466,20 @@
           <CustomServerUrl>
           </CustomServerUrl>
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <servers defaultServer="SelfHostServer">
+            <server name="SelfHostServer" exePath="" cmdArgs="" url="http://localhost:53018/" workingDir="" />
+          </servers>
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets" Condition="Exists('..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -445,9 +445,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
@@ -476,12 +473,6 @@
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets" Condition="Exists('..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -216,10 +216,12 @@
     <Compile Include="LoggingHandler.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\Exceptions\EmptyConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\Exceptions\MalformedConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\HttpValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\KeyVaultValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\StorageValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\MySqlValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />
     <Compile Include="Models\LogsSettings.cs" />

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -29,7 +29,9 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             UnknownResponse,
             EndpointNotReachable,
             ConnectionFailure,
+            DnsLookupFailed,
             MsiFailure,
+            EmptyConnectionString,
             MalformedConnectionString,
             UnknownError
         }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
@@ -12,7 +12,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.EventHubs;
 
-        public async Task<bool> IsValid(string connectionString)
+        public async Task<bool> IsValidAsync(string connectionString)
         {
             try
             {
@@ -25,7 +25,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connectionString, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connectionString, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
@@ -1,0 +1,78 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.Azure.EventHubs;
+using System;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class EventHubsValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.Azure.EventHubs";
+
+        public ConnectionStringType Type => ConnectionStringType.EventHubs;
+
+        public async Task<bool> IsValid(string connectionString)
+        {
+            try
+            {
+                new EventHubsConnectionStringBuilder(connectionString);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connectionString, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connectionString, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+            var client = EventHubClient.CreateFromConnectionString(connectionString);
+            await client.CloseAsync();
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
@@ -51,6 +51,24 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
                 }
+                else if (e is ArgumentNullException ||
+                         e.Message.Contains("could not be found") ||
+                         e.Message.Contains("was not found"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e.Message.Contains("No such host is known"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else if (e.Message.Contains("InvalidSignature"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                }
+                else if (e.Message.Contains("Ip has been prevented to connect to the endpoint"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                }
                 else
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
@@ -70,6 +88,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 Succeeded = true
             };
             var client = EventHubClient.CreateFromConnectionString(connectionString);
+            await client.GetRuntimeInformationAsync();
             await client.CloseAsync();
 
             return data;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/EmptyConnectionStringException.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/EmptyConnectionStringException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions
+{
+    public class EmptyConnectionStringException: Exception
+    {
+        public EmptyConnectionStringException() : base()
+        { 
+        }
+
+        public EmptyConnectionStringException(string message) : base(message)
+        { 
+        }
+
+        public EmptyConnectionStringException(string message, Exception innerException) : base(message, innerException)
+        { 
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
@@ -20,7 +20,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.Http;
 
-        public async Task<bool> IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -33,7 +33,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             }
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
@@ -20,14 +20,10 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.Http;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValid(string connStr)
         {
             try
             {
-                if (!connStr.StartsWith("http"))
-                {
-                    connStr += "https://";
-                }
                 var uri = new Uri(connStr);
                 return true;
             }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -9,9 +9,9 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
     interface IConnectionStringValidator
     {
         // verify provided string is a valid connection string that can be tested by the validator
-        Task<bool> IsValid(string connStr);
+        Task<bool> IsValidAsync(string connStr);
 
-        Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
+        Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
 
         string ProviderName { get; }
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -9,7 +9,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
     interface IConnectionStringValidator
     {
         // verify provided string is a valid connection string that can be tested by the validator
-        bool IsValid(string connStr);
+        Task<bool> IsValid(string connStr);
 
         Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
@@ -20,7 +20,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.KeyVault;
 
-        public async Task<bool> IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -41,7 +41,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             }
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
@@ -20,7 +20,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.KeyVault;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValid(string connStr)
         {
             try
             {

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.MySql;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValid(string connStr)
         {
             try
             {
@@ -34,15 +34,6 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
             try
             {
-                try
-                {
-                    var builder = new MySqlConnectionStringBuilder(connStr);
-                }
-                catch (Exception e)
-                {
-                    throw new MalformedConnectionStringException(e.Message, e);
-                }
-
                 var result = await TestMySqlConnectionString(connStr, null, clientId);
                 if (result.Succeeded)
                 {
@@ -90,6 +81,15 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public async Task<TestConnectionData> TestMySqlConnectionString(string connectionString, string name, string clientId)
         {
+            try
+            {
+                var builder = new MySqlConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+
             TestConnectionData data = new TestConnectionData
             {
                 ConnectionString = connectionString,

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.MySql;
 
-        public async Task<bool> IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -28,7 +28,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.ServiceBus;
 
-        public async Task<bool> IsValid(string connectionString)
+        public async Task<bool> IsValidAsync(string connectionString)
         {
             try
             {
@@ -28,7 +28,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connectionString, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connectionString, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
@@ -1,0 +1,102 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Management;
+using System;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class ServiceBusValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.Azure.ServiceBus";
+
+        public ConnectionStringType Type => ConnectionStringType.ServiceBus;
+
+        public async Task<bool> IsValid(string connectionString)
+        {
+            try
+            {
+                new ServiceBusConnectionStringBuilder(connectionString);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connectionString, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connectionString, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException || e is ArgumentNullException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else if (e is ArgumentException && e.Message.Contains("Authentication "))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                }
+                else if (e.InnerException != null && e.InnerException.InnerException != null &&
+                         e.InnerException.InnerException.Message.Contains("The remote name could not be resolved"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name = null, string clientId = null)
+        {
+            if (String.IsNullOrEmpty(connectionString))
+            {
+                throw new EmptyConnectionStringException();
+            }
+            ServiceBusConnectionStringBuilder builder = null;
+            try
+            {
+                builder = new ServiceBusConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+
+            var mgmtClient = new ManagementClient(builder);
+            //await mgmtClient.GetNamespaceInfoAsync();
+            await mgmtClient.GetQueuesAsync();
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.SqlServer;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValid(string connStr)
         {
             try
             {
@@ -34,15 +34,6 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
             try
             {
-                try
-                {
-                    var builder = new SqlConnectionStringBuilder(connStr);
-                }
-                catch (Exception e)
-                {
-                    throw new MalformedConnectionStringException(e.Message ,e);
-                }
-
                 var result = await TestSqlServerConnectionString(connStr, null, clientId);
                 if (result.Succeeded)
                 {
@@ -114,6 +105,15 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 Name = name
             };
             data.Succeeded = false;
+
+            try
+            {
+                var builder = new SqlConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
 
             using (SqlConnection conn = new SqlConnection())
             {

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.SqlServer;
 
-        public async Task<bool> IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -28,7 +28,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        public async Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        public async Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
@@ -104,9 +104,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
             CloudBlobClient client = storageAccount.CreateCloudBlobClient();
             client.GetServiceProperties();
-            IEnumerable<CloudBlobContainer> containers = client.ListContainers();
-            if (containers.Count() == 0)
-            { }
+            client.ListContainers();
 
             return data;
         }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
@@ -1,0 +1,114 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class StorageValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.WindowsAzure.Storage";
+
+        public ConnectionStringType Type => ConnectionStringType.StorageAccount;
+
+        public async Task<bool> IsValid(string connStr)
+        {
+            try
+            {
+                CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connStr);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public async Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connStr, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else if (e.InnerException != null &&
+                         e.InnerException.Message.Contains("The remote name could not be resolved"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else if (e is StorageException)
+                {
+                    if (((StorageException)e).RequestInformation.HttpStatusCode == 401)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else if (((StorageException)e).RequestInformation.HttpStatusCode == 403)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        public async Task<TestConnectionData> TestConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+            CloudStorageAccount storageAccount;
+            try
+            {
+                storageAccount = CloudStorageAccount.Parse(connectionString);
+            }
+            catch (ArgumentNullException e)
+            {
+                throw new EmptyConnectionStringException(e.Message, e);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+
+            CloudBlobClient client = storageAccount.CreateCloudBlobClient();
+            client.GetServiceProperties();
+            IEnumerable<CloudBlobContainer> containers = client.ListContainers();
+            if (containers.Count() == 0)
+            { }
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.StorageAccount;
 
-        public async Task<bool> IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -28,7 +28,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        public async Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        public async Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Web.config
+++ b/DiagnosticsExtension/Web.config
@@ -91,6 +91,22 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -61,7 +61,7 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net48" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" requireReinstallation="true" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net48" />
   <package id="WebGrease" version="1.6.0" targetFramework="net48" />
   <package id="WindowsAzure.Storage" version="9.3.3" targetFramework="net48" />

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -17,12 +17,21 @@
   <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.6" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net48" />
+  <package id="Microsoft.Azure.Amqp" version="2.4.9" targetFramework="net48" />
+  <package id="Microsoft.Azure.EventHubs" version="3.0.0" targetFramework="net48" />
+  <package id="Microsoft.Azure.EventHubs.Processor" version="3.0.0" targetFramework="net48" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net48" />
+  <package id="Microsoft.Azure.ServiceBus" version="4.2.1" targetFramework="net48" />
+  <package id="Microsoft.Azure.Services.AppAuthentication" version="1.0.3" targetFramework="net48" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net48" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net48" />
   <package id="Microsoft.Data.Edm" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Data.Services.Client" version="5.8.4" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.5.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.4.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.4.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.4.0" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Ajax" version="3.2.6" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net48" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net48" />
@@ -36,11 +45,24 @@
   <package id="Swashbuckle" version="5.6.0" targetFramework="net48" />
   <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net48" />
   <package id="System.Data.SqlClient" version="4.8.2" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net48" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.4.0" targetFramework="net48" />
+  <package id="System.IO" version="4.3.0" targetFramework="net48" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net48" />
+  <package id="System.Net.WebSockets" version="4.0.0" targetFramework="net48" />
+  <package id="System.Net.WebSockets.Client" version="4.0.2" targetFramework="net48" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net48" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net48" />
   <package id="WebGrease" version="1.6.0" targetFramework="net48" />
-  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net48" />
+  <package id="WindowsAzure.Storage" version="9.3.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
The following connections strings are supported with this PR:
1. Storage
2. Service Bus
3. Event Hubs

Minor refactor of IsValid to be an async function for consistency and incase future validators call async methods (async all the way)
