### PR TITLE
Adding a new controller and endpoint to validate connection strings

### DIFF
--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -1,0 +1,89 @@
+//-----------------------------------------------------------------------
+// <copyright file="UdpEchoTestController.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using DiagnosticsExtension.Models.ConnectionStringValidator;
+
+namespace DiagnosticsExtension.Controllers
+{
+    /// <summary>
+    /// Worker instances are running an udp echo server on port 30000. This controller is for checking the connection between target 
+    /// worker instance by pinging and checking the echoed result.
+    /// </summary>
+    [RoutePrefix("api/connectionstringvalidation")]
+    public class ConnectionStringValidationController : ApiController
+    {
+        [HttpGet]
+        [Route("validate")]
+        public async Task<HttpResponseMessage> Validate(string connStr, int? typeId = null)
+        {
+            // register all validators here
+            var typeValidatorMap = new IConnectionStringValidator[]
+            {
+                new SqlServerValidator()
+            }.ToDictionary(v => v.Type, v => v);
+
+            if (typeId != null)
+            {
+                var enumType = (ConnectionStringType)typeId.Value;
+                if (typeValidatorMap.ContainsKey(enumType))
+                {
+                    var result = await typeValidatorMap[enumType].Validate(connStr);
+                    return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                }
+                else
+                {
+                    return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"No supported validator found for typeId={typeId.Value}");
+                }
+            }
+            else
+            {
+                var exceptions = new List<Exception>();
+                foreach (var p in typeValidatorMap)
+                {
+                    try
+                    {
+                        if (p.Value.IsValid(connStr))
+                        {
+                            var result = await p.Value.Validate(connStr);
+                            return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, new AggregateException($"No supported validator found for provided connection string", exceptions));
+            }
+        }
+
+        [HttpGet]
+        [Route("validateappsetting")]
+        public async Task<HttpResponseMessage> ValidateAppSetting(string appSettingName, int? typeId = null)
+        {
+            var envDict = Environment.GetEnvironmentVariables();
+            if (envDict.Contains(appSettingName))
+            {
+                var connectionString = (string)envDict[appSettingName];
+                return await Validate(connectionString, typeId);
+            }
+            else
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"AppSetting {appSettingName} not found");
+            }
+        }
+    }
+}

--- a/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
+++ b/DiagnosticsExtension/Controllers/ConnectionStringValidationController.cs
@@ -7,33 +7,46 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using System.Web.Http;
+using DiagnosticsExtension.Models;
 using DiagnosticsExtension.Models.ConnectionStringValidator;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DiagnosticsExtension.Controllers
 {
-    /// <summary>
-    /// Worker instances are running an udp echo server on port 30000. This controller is for checking the connection between target 
-    /// worker instance by pinging and checking the echoed result.
-    /// </summary>
     [RoutePrefix("api/connectionstringvalidation")]
     public class ConnectionStringValidationController : ApiController
     {
+        private IConnectionStringValidator[] validators;
+        private Dictionary<ConnectionStringType, IConnectionStringValidator> typeValidatorMap;
+
+        public ConnectionStringValidationController()
+        {
+            // register all validators here, the order of validators decides the order of connection string matching
+            validators = new IConnectionStringValidator[]
+            {
+                new SqlServerValidator(),
+                new MySqlValidator(),
+                new KeyVaultValidator(),
+                new HttpValidator()
+            };
+            typeValidatorMap = validators.ToDictionary(v => v.Type, v => v);
+        }
+
         [HttpGet]
         [Route("validate")]
         public async Task<HttpResponseMessage> Validate(string connStr, int? typeId = null)
         {
-            // register all validators here
-            var typeValidatorMap = new IConnectionStringValidator[]
-            {
-                new SqlServerValidator()
-            }.ToDictionary(v => v.Type, v => v);
+            
 
             if (typeId != null)
             {
@@ -41,7 +54,7 @@ namespace DiagnosticsExtension.Controllers
                 if (typeValidatorMap.ContainsKey(enumType))
                 {
                     var result = await typeValidatorMap[enumType].Validate(connStr);
-                    return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                    return Request.CreateResponse(HttpStatusCode.OK, result);
                 }
                 else
                 {
@@ -51,14 +64,14 @@ namespace DiagnosticsExtension.Controllers
             else
             {
                 var exceptions = new List<Exception>();
-                foreach (var p in typeValidatorMap)
+                foreach (var validator in validators)
                 {
                     try
                     {
-                        if (p.Value.IsValid(connStr))
+                        if (validator.IsValid(connStr))
                         {
-                            var result = await p.Value.Validate(connStr);
-                            return Request.CreateResponse(HttpStatusCode.OK, new { result, connStr });
+                            var result = await validator.Validate(connStr);
+                            return Request.CreateResponse(HttpStatusCode.OK, result);
                         }
                     }
                     catch (Exception e)
@@ -68,6 +81,46 @@ namespace DiagnosticsExtension.Controllers
                 }
                 return Request.CreateErrorResponse(HttpStatusCode.NotFound, new AggregateException($"No supported validator found for provided connection string", exceptions));
             }
+        }
+
+        [HttpPost]
+        [Route("validate")]
+        public async Task<HttpResponseMessage> Validate()
+        {
+            var body = await Request.Content.ReadAsStringAsync();
+            string connStr = null;
+            int? typeId = null;
+            string type = null;
+            try
+            {
+                var json = JsonConvert.DeserializeObject<JToken>(body);
+                connStr = (string)json["connStr"];
+                typeId = (int?)json["typeId"];
+                type = (string)json["type"];
+                if (string.IsNullOrWhiteSpace(connStr))
+                {
+                    throw new Exception("Null or empty connection string");
+                }
+            }
+            catch (Exception e)
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, e);
+            }
+            if (typeId == null && type != null) 
+            {
+                bool success = Enum.TryParse(type, out ConnectionStringType csType);
+                if (success)
+                {
+                    typeId = (int) csType;
+                }
+                else
+                {
+                    return Request.CreateErrorResponse(HttpStatusCode.BadRequest, $"type {type} is not supported");
+                }
+            }
+
+            var result = await Validate(connStr, typeId);
+            return result;
         }
 
         [HttpGet]
@@ -83,6 +136,21 @@ namespace DiagnosticsExtension.Controllers
             else
             {
                 return Request.CreateErrorResponse(HttpStatusCode.NotFound, $"AppSetting {appSettingName} not found");
+            }
+        }
+
+        [HttpGet]
+        [Route("validateappsetting")]
+        public async Task<HttpResponseMessage> ValidateAppSetting(string appSettingName, string type)
+        {
+            bool success = Enum.TryParse(type, out ConnectionStringType csType);
+            if (success)
+            {
+                return await ValidateAppSetting(appSettingName, (int)csType);
+            }
+            else
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, $"type {type} is not supported");
             }
         }
     }

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -216,7 +216,11 @@
     <Compile Include="LoggingHandler.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\Exceptions\MalformedConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\HttpValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\KeyVaultValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\MySqlValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />
     <Compile Include="Models\LogsSettings.cs" />
     <Compile Include="Models\MsiValidatorModels.cs" />

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -61,8 +61,23 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Amqp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Amqp.2.4.9\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.EventHubs, Version=3.0.0.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.EventHubs.3.0.0\lib\net461\Microsoft.Azure.EventHubs.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.EventHubs.Processor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.EventHubs.Processor.3.0.0\lib\net461\Microsoft.Azure.EventHubs.Processor.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.ServiceBus, Version=4.2.1.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.ServiceBus.4.2.1\lib\netstandard2.0\Microsoft.Azure.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Services.AppAuthentication, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\lib\net452\Microsoft.Azure.Services.AppAuthentication.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -74,11 +89,23 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.5.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.4.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.4.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.4.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.Storage.9.3.3\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
@@ -96,14 +123,30 @@
       <HintPath>..\packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Data.SqlClient, Version=4.6.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SqlClient.4.8.2\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.4.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
@@ -113,10 +156,45 @@
     <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.WebSockets, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.4.0.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.WebSockets.Client, Version=4.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.WebSockets.Client.4.0.2\lib\net46\System.Net.WebSockets.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.TypeExtensions.4.5.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.8.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
@@ -167,12 +245,11 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
@@ -216,10 +293,14 @@
     <Compile Include="LoggingHandler.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\EventHubsValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\Exceptions\EmptyConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\Exceptions\MalformedConnectionStringException.cs" />
     <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\HttpValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\KeyVaultValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ServiceBusValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\StorageValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\MySqlValidator.cs" />
     <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />
     <Compile Include="Models\LogsSettings.cs" />
@@ -374,7 +455,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
+          <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>53018</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
@@ -384,10 +465,14 @@
           <CustomServerUrl>
           </CustomServerUrl>
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <servers defaultServer="SelfHostServer">
+            <server name="SelfHostServer" exePath="" cmdArgs="" url="http://localhost:53018/" workingDir="" />
+          </servers>
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets" Condition="Exists('..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Controllers\CpuMonitoringController.cs" />
     <Compile Include="Controllers\CrashMonitoringController.cs" />
     <Compile Include="Controllers\DaasAdministerController.cs" />
+    <Compile Include="Controllers\ConnectionStringValidationController.cs" />
     <Compile Include="Controllers\UdpEchoTestController.cs" />
     <Compile Include="Controllers\DatabaseTestController.cs" />
     <Compile Include="Controllers\DownloadFileController.cs" />
@@ -213,6 +214,10 @@
     <Compile Include="Controllers\SessionsController.cs" />
     <Compile Include="Controllers\StdoutLogsController.cs" />
     <Compile Include="LoggingHandler.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
+    <Compile Include="Models\ConnectionStringValidator\IConnectionStringValidator.cs" />
+    <Compile Include="Models\ConnectionStringValidator\SqlServerValidator.cs" />
     <Compile Include="Models\LogsSettings.cs" />
     <Compile Include="Models\MsiValidatorModels.cs" />
     <Compile Include="Models\SasUriResponse.cs" />

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Controllers\SessionsController.cs" />
     <Compile Include="Controllers\StdoutLogsController.cs" />
     <Compile Include="LoggingHandler.cs" />
+    <Compile Include="Models\ConnectionStringValidator\ConnectionStringRequestBody.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringType.cs" />
     <Compile Include="Models\ConnectionStringValidator\ConnectionStringValidationResult.cs" />
     <Compile Include="Models\ConnectionStringValidator\EventHubsValidator.cs" />

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringRequestBody.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringRequestBody.cs
@@ -1,5 +1,5 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="ConnectionStringType.cs" company="Microsoft Corporation">
+//-----------------------------------------------------------------------
+// <copyright file="ConnectionStringRequestBody.cs" company="Microsoft Corporation">
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // </copyright>
@@ -12,15 +12,9 @@ using System.Web;
 
 namespace DiagnosticsExtension.Models.ConnectionStringValidator
 {
-    public enum ConnectionStringType
+    public class ConnectionStringRequestBody
     {
-        SqlServer,
-        MySql,
-        KeyVault,
-        Http,
-        RedisCache,
-        StorageAccount,
-        ServiceBus,
-        EventHubs
+        public string ConnectionString { get; set; }
+        public string Type { get; set; }
     }
 }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringType.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public enum ConnectionStringType
+    {
+        // Jeff
+        SqlServer,
+        MySql,
+        KeyVault,
+        Http,
+        RedisCache,
+
+        // Sid
+        StorageAccount,
+        ServiceBus,
+        EventHubs,
+        CosmosDB
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -29,7 +29,9 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             UnknownResponse,
             EndpointNotReachable,
             ConnectionFailure,
+            DnsLookupFailed,
             MsiFailure,
+            EmptyConnectionString,
             MalformedConnectionString,
             UnknownError
         }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConnectionStringValidationResult.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -8,17 +8,32 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
     public class ConnectionStringValidationResult
     {
+        public ResultStatus? Status;
+        public string StatusText => Status?.ToString();
+        public Exception Exception;
+        public object Payload;
+        public string Type => type.ToString();
+
+        private ConnectionStringType type;
+
+        public ConnectionStringValidationResult(ConnectionStringType type)
+        {
+            this.type = type;
+        }
         public enum ResultStatus
         {
             Success,
             AuthFailure,
+            ContentNotFound,
+            Forbidden,
+            UnknownResponse,
+            EndpointNotReachable,
             ConnectionFailure,
-            EndpointNotFound,
             MsiFailure,
+            MalformedConnectionString,
             UnknownError
         }
 
-        public ResultStatus Status;
-        public Exception Exception;
+        
     }
 }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ConnectionStringValidationResult.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+
+    public class ConnectionStringValidationResult
+    {
+        public enum ResultStatus
+        {
+            Success,
+            AuthFailure,
+            ConnectionFailure,
+            EndpointNotFound,
+            MsiFailure,
+            UnknownError
+        }
+
+        public ResultStatus Status;
+        public Exception Exception;
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventHubsValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using Microsoft.Azure.EventHubs;
 using System;
@@ -31,7 +38,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
             try
             {
-                var result = await TestConnectionString(connectionString, null, clientId);
+                var result = await TestConnectionStringAsync(connectionString, null, clientId);
                 if (result.Succeeded)
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.Success;
@@ -79,7 +86,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return response;
         }
 
-        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name, string clientId)
+        protected async Task<TestConnectionData> TestConnectionStringAsync(string connectionString, string name, string clientId)
         {
             TestConnectionData data = new TestConnectionData
             {

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/EventHubsValidator.cs
@@ -1,0 +1,97 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.Azure.EventHubs;
+using System;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class EventHubsValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.Azure.EventHubs";
+
+        public ConnectionStringType Type => ConnectionStringType.EventHubs;
+
+        public async Task<bool> IsValidAsync(string connectionString)
+        {
+            try
+            {
+                new EventHubsConnectionStringBuilder(connectionString);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connectionString, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connectionString, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else if (e is ArgumentNullException ||
+                         e.Message.Contains("could not be found") ||
+                         e.Message.Contains("was not found"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e.Message.Contains("No such host is known"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else if (e.Message.Contains("InvalidSignature"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                }
+                else if (e.Message.Contains("Ip has been prevented to connect to the endpoint"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+            var client = EventHubClient.CreateFromConnectionString(connectionString);
+            await client.GetRuntimeInformationAsync();
+            await client.CloseAsync();
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/EmptyConnectionStringException.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/EmptyConnectionStringException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions
+{
+    public class EmptyConnectionStringException: Exception
+    {
+        public EmptyConnectionStringException() : base()
+        { 
+        }
+
+        public EmptyConnectionStringException(string message) : base(message)
+        { 
+        }
+
+        public EmptyConnectionStringException(string message, Exception innerException) : base(message, innerException)
+        { 
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/MalformedConnectionStringException.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/Exceptions/MalformedConnectionStringException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions
+{
+    public class MalformedConnectionStringException: Exception
+    {
+        public MalformedConnectionStringException() : base()
+        { 
+        }
+
+        public MalformedConnectionStringException(string message) : base(message)
+        { 
+        }
+
+        public MalformedConnectionStringException(string message, Exception innerException) : base(message, innerException)
+        { 
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
@@ -20,14 +20,10 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.Http;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
-                if (!connStr.StartsWith("http"))
-                {
-                    connStr += "https://";
-                }
                 var uri = new Uri(connStr);
                 return true;
             }
@@ -37,7 +33,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             }
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
@@ -1,0 +1,104 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class HttpValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "System.Net.Http";
+
+        public ConnectionStringType Type => ConnectionStringType.Http;
+
+        public bool IsValid(string connStr)
+        {
+            try
+            {
+                if (!connStr.StartsWith("http"))
+                {
+                    connStr += "https://";
+                }
+                var uri = new Uri(connStr);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    if (!connStr.StartsWith("http"))
+                    {
+                        connStr += "https://";
+                    }
+                    var uri = new Uri(connStr);
+
+
+                    var resp = await client.GetAsync(connStr);
+                    int statusCode = (int)resp.StatusCode;
+                    response.Payload = $"StatusCode: {statusCode}";
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                    }
+                    else if (statusCode == 401)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else if (statusCode == 403)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                    else if (statusCode == 404)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.ContentNotFound;
+                    }
+                    else
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.UnknownResponse;
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (e is HttpRequestException)
+                    {
+                        var inner = e.InnerException;
+                        if (inner!= null && (inner.Message.StartsWith("The remote name could not be resolved") || inner.Message.StartsWith("Unable to connect to the remote server")))
+                        {
+                            response.Status = ConnectionStringValidationResult.ResultStatus.EndpointNotReachable;
+                        }
+                        else
+                        {
+                            response.Status = ConnectionStringValidationResult.ResultStatus.ConnectionFailure;
+                        }
+                    }
+                    else
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                    }
+                    response.Exception = e;
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/HttpValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="HttpValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    interface IConnectionStringValidator
+    {
+        // verify provided string is a valid connection string that can be tested by the validator
+        bool IsValid(string connStr);
+
+        Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
+
+        string ProviderName { get; }
+
+        ConnectionStringType Type { get; }
+
+
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -9,9 +9,9 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
     interface IConnectionStringValidator
     {
         // verify provided string is a valid connection string that can be tested by the validator
-        bool IsValid(string connStr);
+        Task<bool> IsValidAsync(string connStr);
 
-        Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
+        Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null);  // clientId used for Used Assigned Managed Identity
 
         string ProviderName { get; }
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/IConnectionStringValidator.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="IConnectionStringValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
@@ -1,0 +1,152 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class KeyVaultValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "System.Net.Http";
+
+        public ConnectionStringType Type => ConnectionStringType.KeyVault;
+
+        public bool IsValid(string connStr)
+        {
+            try
+            {
+                if (!connStr.StartsWith("http"))
+                {
+                    connStr += "https://";
+                }
+                var uri = new Uri(connStr);
+                if (!uri.Host.ToLower().EndsWith("vault.azure.net"))
+                {
+                    throw new MalformedConnectionStringException("Malformed KeyVault connection string. A valid KV connection string should has hostname ends with vault.azure.net.");
+                }
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    if (!connStr.StartsWith("http"))
+                    {
+                        connStr += "https://";
+                    }
+                    var uri = new Uri(connStr);
+                    if (!uri.Host.ToLower().EndsWith("vault.azure.net"))
+                    {
+                        throw new MalformedConnectionStringException("Malformed KeyVault connection string. A valid KV connection string should has hostname ends with vault.azure.net.");
+                    }
+
+                    if (!uri.Query.Contains("api-version"))
+                    {
+                        if (uri.Query == string.Empty)
+                        {
+                            connStr += "?";
+                        }
+                        else
+                        {
+                            connStr += "&";
+                        }
+                        connStr += "api-version=7.1";
+                    }
+
+                    MsiValidator msi = new MsiValidator();
+                    if (msi.IsEnabled())
+                    {
+                        MsiValidatorInput input = new MsiValidatorInput(ResourceType.KeyVault, clientId);
+                        bool success = await msi.GetTokenAsync(input);
+                        var msiResult = msi.Result.GetTokenTestResult;
+
+                        if (success)
+                        {
+                            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", msiResult.TokenInformation.AccessToken);
+                        }
+                        else
+                        {
+                            response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailure;
+                            var e = new Exception(msiResult.ErrorDetails.Message);
+                            e.Data["AdalError"] = msiResult.ErrorDetails;
+                            throw e;
+                        }
+                    }
+
+                    var resp = await client.GetAsync(connStr);
+                    int statusCode = (int)resp.StatusCode;
+                    response.Payload = $"StatusCode: {statusCode}";
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                    }
+                    else if (statusCode == 401)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else if (statusCode == 403)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                    else if (statusCode == 404)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.ContentNotFound;
+                    }
+                    else
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.UnknownResponse;
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    response.Exception = e;
+                    if (response.Status == null)
+                    {
+                        if (e is MalformedConnectionStringException)
+                        {
+                            response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                        }
+                        else if (e is HttpRequestException)
+                        {
+                            var inner = e.InnerException;
+                            if (inner != null && (inner.Message.StartsWith("The remote name could not be resolved") || inner.Message.StartsWith("Unable to connect to the remote server")))
+                            {
+                                response.Status = ConnectionStringValidationResult.ResultStatus.EndpointNotReachable;
+                            }
+                            else
+                            {
+                                response.Status = ConnectionStringValidationResult.ResultStatus.ConnectionFailure;
+                            }
+                        }
+                        else
+                        {
+                            response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                        }
+                    }
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
@@ -20,7 +20,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.KeyVault;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -41,7 +41,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             }
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/KeyVaultValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="KeyVaultValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="MySqlValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using MySql.Data.MySqlClient;
 using System;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
@@ -1,0 +1,108 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class MySqlValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "MySql.Data.MySqlClient";
+
+        public ConnectionStringType Type => ConnectionStringType.MySql;
+
+        public bool IsValid(string connStr)
+        {
+            try
+            {
+                var builder = new MySqlConnectionStringBuilder(connStr);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                try
+                {
+                    var builder = new MySqlConnectionStringBuilder(connStr);
+                }
+                catch (Exception e)
+                {
+                    throw new MalformedConnectionStringException(e.Message, e);
+                }
+
+                var result = await TestMySqlConnectionString(connStr, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is MySqlException)
+                {
+                    if (e.Message.StartsWith("Unable to connect to any of the specified MySQL hosts."))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.EndpointNotReachable;
+                    }
+                    else if (e.Message.Contains("not allowed"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                    else if (e.Message.StartsWith("Authentication to host"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                    }
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        public async Task<TestConnectionData> TestMySqlConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name
+            };
+            using (MySqlConnection conn = new MySqlConnection())
+            {
+                conn.ConnectionString = connectionString;
+                await conn.OpenAsync();
+                data.Succeeded = true;
+            }
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/MySqlValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.MySql;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -28,21 +28,12 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 
             try
             {
-                try
-                {
-                    var builder = new MySqlConnectionStringBuilder(connStr);
-                }
-                catch (Exception e)
-                {
-                    throw new MalformedConnectionStringException(e.Message, e);
-                }
-
                 var result = await TestMySqlConnectionString(connStr, null, clientId);
                 if (result.Succeeded)
                 {
@@ -90,6 +81,15 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public async Task<TestConnectionData> TestMySqlConnectionString(string connectionString, string name, string clientId)
         {
+            try
+            {
+                var builder = new MySqlConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+
             TestConnectionData data = new TestConnectionData
             {
                 ConnectionString = connectionString,

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
@@ -1,0 +1,119 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Azure.ServiceBus.Management;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class ServiceBusValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.Azure.ServiceBus";
+
+        public ConnectionStringType Type => ConnectionStringType.ServiceBus;
+
+        public async Task<bool> IsValidAsync(string connectionString)
+        {
+            try
+            {
+                new ServiceBusConnectionStringBuilder(connectionString);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        async public Task<ConnectionStringValidationResult> ValidateAsync(string connectionString, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connectionString, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException || e is ArgumentNullException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else if (e is ArgumentException && e.Message.Contains("Authentication "))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                }
+                else if (e is ArgumentException && e.Message.Contains("entityPath is null") ||
+                         e.Message.Contains("HostNotFound") ||
+                         e.Message.Contains("could not be found") ||
+                         e.Message.Contains("The argument  is null or white space"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e.InnerException != null && e.InnerException.InnerException != null &&
+                         e.InnerException.InnerException.Message.Contains("The remote name could not be resolved"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else if (e.Message.Contains("claim is empty or token is invalid"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                }
+                else if (e.Message.Contains("Ip has been prevented to connect to the endpoint"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name = null, string clientId = null)
+        {
+            if (String.IsNullOrEmpty(connectionString))
+            {
+                throw new EmptyConnectionStringException();
+            }
+            ServiceBusConnectionStringBuilder connectionStringBuilder = null;
+            try
+            {
+                connectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+
+            MessageReceiver msgReceiver = new MessageReceiver(connectionStringBuilder, ReceiveMode.PeekLock, prefetchCount: 1);
+            Message msg = await msgReceiver.PeekAsync();
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/ServiceBusValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="ServiceBusValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
@@ -34,7 +41,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
             try
             {
-                var result = await TestConnectionString(connectionString, null, clientId);
+                var result = await TestConnectionStringAsync(connectionString, null, clientId);
                 if (result.Succeeded)
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.Success;
@@ -54,7 +61,9 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
                 }
-                else if (e is ArgumentException && e.Message.Contains("Authentication "))
+                else if ((e is ArgumentException && e.Message.Contains("Authentication ")) ||
+                         e.Message.Contains("claim is empty or token is invalid") ||
+                         e.Message.Contains("InvalidSignature"))
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
                 }
@@ -70,10 +79,6 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
                 }
-                else if (e.Message.Contains("claim is empty or token is invalid"))
-                {
-                    response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
-                }
                 else if (e.Message.Contains("Ip has been prevented to connect to the endpoint"))
                 {
                     response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
@@ -88,7 +93,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return response;
         }
 
-        protected async Task<TestConnectionData> TestConnectionString(string connectionString, string name = null, string clientId = null)
+        protected async Task<TestConnectionData> TestConnectionStringAsync(string connectionString, string name = null, string clientId = null)
         {
             if (String.IsNullOrEmpty(connectionString))
             {

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class SqlServerValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "System.Data.SqlClient";
+
+        public ConnectionStringType Type => ConnectionStringType.SqlServer;
+
+        public bool IsValid(string connStr)
+        {
+            throw new NotImplementedException();
+        }
+
+        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult();
+            using (SqlConnection conn = new SqlConnection())
+            {
+                try
+                {
+                    conn.ConnectionString = connStr;
+                    SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(conn.ConnectionString);
+                    string userId = builder.UserID;
+                    string password = builder.Password;
+
+                    if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(password))
+                    {
+                        MsiValidator msi = new MsiValidator();
+
+                        if (msi.IsEnabled())
+                        {
+                            var input = new MsiValidatorInput(ResourceType.Sql, clientId);
+                            bool hasConnectivityWithAzureAd = await msi.GetTokenAsync(input);
+
+                            if (hasConnectivityWithAzureAd)
+                            {
+                                conn.AccessToken = msi.Result.GetTokenTestResult.TokenInformation.AccessToken;
+                            }
+                            else
+                            {
+                                var adalError = msi.Result.GetTokenTestResult.ErrorDetails;
+                                var e = new Exception(adalError.Message);
+                                e.Data["AdalError"] = adalError;
+                                response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailure;
+                                response.Exception = e;
+                                return response;
+                            }
+                        }
+                    }
+
+
+                    await conn.OpenAsync();
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                catch (Exception e)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                    response.Exception = e;
+                }
+
+                return response;
+            }
+        }
+    }
+}

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
@@ -15,58 +17,145 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public bool IsValid(string connStr)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var builder = new SqlConnectionStringBuilder(connStr);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
 
-        async public Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        public async Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
         {
-            var response = new ConnectionStringValidationResult();
-            using (SqlConnection conn = new SqlConnection())
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
             {
                 try
                 {
-                    conn.ConnectionString = connStr;
-                    SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(conn.ConnectionString);
-                    string userId = builder.UserID;
-                    string password = builder.Password;
-
-                    if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(password))
-                    {
-                        MsiValidator msi = new MsiValidator();
-
-                        if (msi.IsEnabled())
-                        {
-                            var input = new MsiValidatorInput(ResourceType.Sql, clientId);
-                            bool hasConnectivityWithAzureAd = await msi.GetTokenAsync(input);
-
-                            if (hasConnectivityWithAzureAd)
-                            {
-                                conn.AccessToken = msi.Result.GetTokenTestResult.TokenInformation.AccessToken;
-                            }
-                            else
-                            {
-                                var adalError = msi.Result.GetTokenTestResult.ErrorDetails;
-                                var e = new Exception(adalError.Message);
-                                e.Data["AdalError"] = adalError;
-                                response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailure;
-                                response.Exception = e;
-                                return response;
-                            }
-                        }
-                    }
-
-
-                    await conn.OpenAsync();
-                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                    var builder = new SqlConnectionStringBuilder(connStr);
                 }
                 catch (Exception e)
                 {
-                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
-                    response.Exception = e;
+                    throw new MalformedConnectionStringException(e.Message ,e);
                 }
 
-                return response;
+                var result = await TestSqlServerConnectionString(connStr, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    if (result.MsiAdalError != null)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.MsiFailure;
+                        var e = new Exception(result.MsiAdalError.Message);
+                        e.Data["AdalError"] = result.MsiAdalError;
+                        response.Exception = e;
+                    }
+                    else
+                    {
+                        throw new Exception("Unexpected state reached: result.Succeeded == false &&  result.MsiAdalError == null is unexpected!");
+                    }
+                }
             }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is InvalidOperationException && e.Message.StartsWith("Cannot set the AccessToken property"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is SqlException)
+                {
+                    if (e.Message.Contains("The server was not found or was not accessible"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.EndpointNotReachable;
+                    }
+                    else if (e.Message.StartsWith("A network-related or instance-specific error"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.ConnectionFailure;
+                    }
+                    else if (e.Message.ToLower().Contains("login failed"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else if (e.Message.Contains("not allow"))
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                    else
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                    }
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        public async Task<TestConnectionData> TestSqlServerConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name
+            };
+            data.Succeeded = false;
+
+            using (SqlConnection conn = new SqlConnection())
+            {
+                conn.ConnectionString = connectionString;
+                SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(conn.ConnectionString);
+                string userId = builder.UserID;
+                string password = builder.Password;
+                bool hasConnectivityWithAzureAd = true;
+
+                if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(password))
+                {
+                    // when we have access token from azure ad
+                    MsiValidator msi = new MsiValidator();
+
+                    data.IsMsiEnabled = msi.IsEnabled();
+
+                    if (data.IsMsiEnabled)
+                    {
+                        MsiValidatorInput input = new MsiValidatorInput(ResourceType.Sql, clientId);
+                        hasConnectivityWithAzureAd = await msi.GetTokenAsync(input);
+
+                        if (hasConnectivityWithAzureAd)
+                        {
+                            conn.AccessToken = msi.Result.GetTokenTestResult.TokenInformation.AccessToken;
+                            await conn.OpenAsync();
+                            data.Succeeded = true;
+                        }
+                        else
+                        {
+                            data.MsiAdalError = msi.Result.GetTokenTestResult.ErrorDetails;
+                        }
+                    }
+                }
+                else
+                {
+                    // when connectionString has credentials
+                    await conn.OpenAsync();
+                    data.Succeeded = true;
+                }
+            }
+
+            return data;
         }
     }
 }

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="SqlServerValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using System;
 using System.Collections.Generic;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/SqlServerValidator.cs
@@ -15,7 +15,7 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
 
         public ConnectionStringType Type => ConnectionStringType.SqlServer;
 
-        public bool IsValid(string connStr)
+        public async Task<bool> IsValidAsync(string connStr)
         {
             try
             {
@@ -28,21 +28,12 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
             return true;
         }
 
-        public async Task<ConnectionStringValidationResult> Validate(string connStr, string clientId = null)
+        public async Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
         {
             var response = new ConnectionStringValidationResult(Type);
 
             try
             {
-                try
-                {
-                    var builder = new SqlConnectionStringBuilder(connStr);
-                }
-                catch (Exception e)
-                {
-                    throw new MalformedConnectionStringException(e.Message ,e);
-                }
-
                 var result = await TestSqlServerConnectionString(connStr, null, clientId);
                 if (result.Succeeded)
                 {
@@ -114,6 +105,15 @@ namespace DiagnosticsExtension.Models.ConnectionStringValidator
                 Name = name
             };
             data.Succeeded = false;
+
+            try
+            {
+                var builder = new SqlConnectionStringBuilder(connectionString);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
 
             using (SqlConnection conn = new SqlConnection())
             {

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
@@ -1,4 +1,11 @@
-﻿using DiagnosticsExtension.Controllers;
+﻿//-----------------------------------------------------------------------
+// <copyright file="StorageValidator.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using DiagnosticsExtension.Controllers;
 using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;

--- a/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
+++ b/DiagnosticsExtension/Models/ConnectionStringValidator/StorageValidator.cs
@@ -1,0 +1,112 @@
+﻿using DiagnosticsExtension.Controllers;
+using DiagnosticsExtension.Models.ConnectionStringValidator.Exceptions;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DiagnosticsExtension.Models.ConnectionStringValidator
+{
+    public class StorageValidator : IConnectionStringValidator
+    {
+        public string ProviderName => "Microsoft.WindowsAzure.Storage";
+
+        public ConnectionStringType Type => ConnectionStringType.StorageAccount;
+
+        public async Task<bool> IsValidAsync(string connStr)
+        {
+            try
+            {
+                CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connStr);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public async Task<ConnectionStringValidationResult> ValidateAsync(string connStr, string clientId = null)
+        {
+            var response = new ConnectionStringValidationResult(Type);
+
+            try
+            {
+                var result = await TestConnectionString(connStr, null, clientId);
+                if (result.Succeeded)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.Success;
+                }
+                else
+                {
+                    throw new Exception("Unexpected state reached: result.Succeeded == false is unexpected!");
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is MalformedConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.MalformedConnectionString;
+                }
+                else if (e is EmptyConnectionStringException)
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.EmptyConnectionString;
+                }
+                else if (e.InnerException != null &&
+                         e.InnerException.Message.Contains("The remote name could not be resolved"))
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.DnsLookupFailed;
+                }
+                else if (e is StorageException)
+                {
+                    if (((StorageException)e).RequestInformation.HttpStatusCode == 401)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.AuthFailure;
+                    }
+                    else if (((StorageException)e).RequestInformation.HttpStatusCode == 403)
+                    {
+                        response.Status = ConnectionStringValidationResult.ResultStatus.Forbidden;
+                    }
+                }
+                else
+                {
+                    response.Status = ConnectionStringValidationResult.ResultStatus.UnknownError;
+                }
+                response.Exception = e;
+            }
+
+            return response;
+        }
+
+        public async Task<TestConnectionData> TestConnectionString(string connectionString, string name, string clientId)
+        {
+            TestConnectionData data = new TestConnectionData
+            {
+                ConnectionString = connectionString,
+                Name = name,
+                Succeeded = true
+            };
+            CloudStorageAccount storageAccount;
+            try
+            {
+                storageAccount = CloudStorageAccount.Parse(connectionString);
+            }
+            catch (ArgumentNullException e)
+            {
+                throw new EmptyConnectionStringException(e.Message, e);
+            }
+            catch (Exception e)
+            {
+                throw new MalformedConnectionStringException(e.Message, e);
+            }
+
+            CloudBlobClient client = storageAccount.CreateCloudBlobClient();
+            client.GetServiceProperties();
+            client.ListContainers();
+
+            return data;
+        }
+    }
+}

--- a/DiagnosticsExtension/Web.config
+++ b/DiagnosticsExtension/Web.config
@@ -91,6 +91,22 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -17,12 +17,21 @@
   <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.6" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net48" />
+  <package id="Microsoft.Azure.Amqp" version="2.4.9" targetFramework="net48" />
+  <package id="Microsoft.Azure.EventHubs" version="3.0.0" targetFramework="net48" />
+  <package id="Microsoft.Azure.EventHubs.Processor" version="3.0.0" targetFramework="net48" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net48" />
+  <package id="Microsoft.Azure.ServiceBus" version="4.2.1" targetFramework="net48" />
+  <package id="Microsoft.Azure.Services.AppAuthentication" version="1.0.3" targetFramework="net48" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net48" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net48" />
   <package id="Microsoft.Data.Edm" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Data.Services.Client" version="5.8.4" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.5.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.4.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.4.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.4.0" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Ajax" version="3.2.6" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net48" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net48" />
@@ -36,11 +45,24 @@
   <package id="Swashbuckle" version="5.6.0" targetFramework="net48" />
   <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net48" />
   <package id="System.Data.SqlClient" version="4.8.2" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net48" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.4.0" targetFramework="net48" />
+  <package id="System.IO" version="4.3.0" targetFramework="net48" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net48" />
+  <package id="System.Net.WebSockets" version="4.0.0" targetFramework="net48" />
+  <package id="System.Net.WebSockets.Client" version="4.0.2" targetFramework="net48" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net48" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" requireReinstallation="true" />
   <package id="WebActivatorEx" version="2.2.0" targetFramework="net48" />
   <package id="WebGrease" version="1.6.0" targetFramework="net48" />
-  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net48" />
+  <package id="WindowsAzure.Storage" version="9.3.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This PR adds a new controller that supports validation of supplied connection strings by making an end-to-end connection using Azure client SDKs.  The goal is to connect to various service endpoints and detect issues around network access, service firewals, invalid/expired auth keys etc.

Changes in this PR were all reviewed and merged into the feature branch that is the source branch of this PR.