### PR TITLE
Add nameresolver api

### DIFF
--- a/DiagnosticsExtension/Controllers/NameResolverController.cs
+++ b/DiagnosticsExtension/Controllers/NameResolverController.cs
@@ -1,0 +1,62 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="UdpEchoTestController.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace DiagnosticsExtension.Controllers
+{
+    /// <summary>
+    /// Worker instances are running an udp echo server on port 30000. This controller is for checking the connection between target 
+    /// worker instance by pinging and checking the echoed result.
+    /// </summary>
+    [RoutePrefix("api/nameresolver")]
+    public class NameResolverController : ApiController
+    {
+        public async Task<HttpResponseMessage> Get(string hostname, bool includeIpV6 = false)
+        {
+            HttpStatusCode httpStatus = HttpStatusCode.OK;
+            NameResolverResult result = null;
+            try
+            {
+                var hostEntry = await Dns.GetHostEntryAsync(hostname);
+                var ips = hostEntry.AddressList.Where(addr => includeIpV6 || addr.AddressFamily != AddressFamily.InterNetworkV6).Select(addr => addr.ToString()).Distinct().ToList();
+                result = new NameResolverResult { Status = "success", IpAddresses = ips };
+                
+            }
+            catch (Exception e)
+            {
+                var socketException = e as SocketException;
+                if (socketException!=null && socketException.SocketErrorCode == SocketError.HostNotFound)
+                {
+                    result = new NameResolverResult { Status = "host not found" };
+                }
+                else
+                {
+                    result = new NameResolverResult { Status = "unknown error", Exception = e };
+                    httpStatus = HttpStatusCode.InternalServerError;
+                }
+            }
+
+            return Request.CreateResponse(httpStatus, result);
+        }
+
+        private class NameResolverResult
+        {
+            public string Status;
+            public List<string> IpAddresses;
+            public Exception Exception;
+        }
+    }
+}

--- a/DiagnosticsExtension/Controllers/NameResolverController.cs
+++ b/DiagnosticsExtension/Controllers/NameResolverController.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="UdpEchoTestController.cs" company="Microsoft Corporation">
+// <copyright file="NameResolverController.cs" company="Microsoft Corporation">
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // </copyright>
@@ -18,8 +18,8 @@ using System.Web.Http;
 namespace DiagnosticsExtension.Controllers
 {
     /// <summary>
-    /// Worker instances are running an udp echo server on port 30000. This controller is for checking the connection between target 
-    /// worker instance by pinging and checking the echoed result.
+    /// This controller simply does a DNS lookup on the worker and returns its result. This is a replacement of nameresolver CLI as it sometimes behaves inconsistently 
+    /// as the name resolving being done in the user code. Mainly used by Network Troubleshooter.
     /// </summary>
     [RoutePrefix("api/nameresolver")]
     public class NameResolverController : ApiController
@@ -38,13 +38,13 @@ namespace DiagnosticsExtension.Controllers
             catch (Exception e)
             {
                 var socketException = e as SocketException;
-                if (socketException!=null && socketException.SocketErrorCode == SocketError.HostNotFound)
+                if (socketException != null && socketException.SocketErrorCode == SocketError.HostNotFound)
                 {
                     result = new NameResolverResult { Status = "host not found" };
                 }
                 else
                 {
-                    result = new NameResolverResult { Status = "unknown error", Exception = e };
+                    result = new NameResolverResult { Status = "error", SocketError = socketException?.SocketErrorCode.ToString(), Exception = e };
                     httpStatus = HttpStatusCode.InternalServerError;
                 }
             }
@@ -57,6 +57,7 @@ namespace DiagnosticsExtension.Controllers
             public string Status;
             public List<string> IpAddresses;
             public Exception Exception;
+            public string SocketError;
         }
     }
 }

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -288,6 +288,7 @@
     <Compile Include="Controllers\DiagnosersV2Controller.cs" />
     <Compile Include="Controllers\SessionV2Controller.cs" />
     <Compile Include="Controllers\SettingsV2Controller.cs" />
+    <Compile Include="Controllers\NameResolverController.cs" />
     <Compile Include="Controllers\UdpEchoTestController.cs" />
     <Compile Include="Controllers\DatabaseTestController.cs" />
     <Compile Include="Controllers\DownloadFileController.cs" />


### PR DESCRIPTION
Sometimes the nameresolver CLI provides a different result as the user app because it implements its own name resolving logic which can introduce more problems and uncertainty to checks in Network Troubleshooter. For example, nameresolver does not check WEBSITE_DNS_ALT_SERVER. And when both DNS in appsetting are not reachable, nameresolver can still produce a result
![image](https://user-images.githubusercontent.com/68874830/136123003-65d667e1-8f98-42e8-b053-76a6d43cec6e.png)

![image](https://user-images.githubusercontent.com/68874830/136123017-5838df08-9552-4cc7-9e20-d5de19ca34d7.png)

Add nameresolver api in DaasExtension to resolve hostname by using C# DNS library, which should provide the same result as the name resolving request sent from user code.