### PR TITLE
Upgrade DiagnosticAnalyis.ResultsViewer to 1.0.1879.56 and Microsoft.VisualStudio.DiagnosticAnalysis.Windows to 17.2.1022301

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -61,7 +61,7 @@
       <Version>11.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.2.1021801</Version>
+      <Version>17.2.1022301</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -378,7 +378,7 @@
     <Content Include="Content\themes\base\jquery-ui.css" />
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.1873.55\content\**\*" >
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.1879.56\content\**\*" >
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -66,5 +66,5 @@
   <package id="Unity.WebAPI" version="5.4.0" targetFramework="net48" />
   <package id="WebGrease" version="1.6.0" targetFramework="net48" />
   <package id="WindowsAzure.Storage" version="9.3.3" targetFramework="net48" />
-  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.1873.55"/>
+  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.1879.56"/>
 </packages>


### PR DESCRIPTION
This upgrade includes support for SourceLink