### PR TITLE
DiagnosticAnalysis: Log the JSON output size

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.cs
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.cs
@@ -173,7 +173,7 @@ namespace DiagnosticAnalysisLauncher
                 }
 
                 var analysis = JsonConvert.DeserializeObject<DiagnosticAnalysis>(diagCliJsonOutput);
-                Logger.LogDiagnoserEvent(JsonConvert.SerializeObject(new { Dump = dumpName, Analysis = analysis }));
+                Logger.LogDiagnoserEvent(JsonConvert.SerializeObject(new { Dump = dumpName, Analysis = analysis, JsonOutputLength = diagCliJsonOutput.Length }));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Log the JSON size so we can monitor it and find ways of decreasing it if we find out it's a problem.

Keep in mind we don't track the size in bytes, but the .NET-encoded string (UTF-16/UTF-8?) length. The two numbers should be close enough (the CLI JSON mostly writes ASCII code points) and I don't think it makes sense to compute the byte size just for minor differences.