### PR TITLE
DiagnosticAnalysis: Use the Join-ResultsViewer.ps1 script to generate the single-file report

### DIFF
--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -370,7 +370,7 @@
     </Content>
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.1949.72\content\prod\**\*" Exclude="**\*.js.map">
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.1949.72\content\client\**\*" Exclude="**\*.js.map">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Updated `DiagnosticAnalysisLauncher` to call `Join-ResultsViewer.ps1` - a script that ships in the `ResultsViewer` nuget package. This script will combine the base html viewer with the JSON results and produce a standalone single html file that can be redistributed.