### PR TITLE
Upgrade DiagnosticAnalyis.ResultsViewer to 1.0.2054.97 and Microsoft.VisualStudio.DiagnosticAnalysis.Windows to 17.4.1081701

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -59,7 +59,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.4.1081101</Version>
+      <Version>17.4.1081701</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -365,7 +365,7 @@
     </Content>
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2046.95\content\client\**\*" Exclude="**\*.js.map">
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2054.97\content\client\**\*" Exclude="**\*.js.map">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -65,5 +65,5 @@
   <package id="Unity.WebAPI" version="5.4.0" targetFramework="net48" />
   <package id="WebGrease" version="1.6.0" targetFramework="net48" />
   <package id="WindowsAzure.Storage" version="9.3.3" targetFramework="net48" />
-  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2046.95"/>
+  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2054.97"/>
 </packages>


### PR DESCRIPTION
The new CLI has a fix that re-enables the UnhandledExceptionAnalysis and the ResultsViewer has a fix in the results JSON validation, so it matches to what the CLI produces