### PR TITLE
Updated DiagnosticAnalysis CLI to 17.4.1091001

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -59,7 +59,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.4.1081701</Version>
+      <Version>17.4.1091001</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The new version allows for running a subset of analyzers by their identifier GUID. 

To do so, add the argument `--run-only` with a semicolon-separated string of GUIDS representing what analyzers should be run. For example, `--run-only "725a55e8-7984-43da-92c9-5aa67e53f029;3d173dbb-0987-45c3-b0bf-fb6b6071b584"`

In order to view what analyzers are available and what their associated GUIDs are, use the `list` option to show available analyzers and their info instead of running analysis.