### PR TITLE
DiagnosticAnalysisLauncher: Construct the dump blob URI and pass it to Join-ResultsViewer.ps1

### DIFF
--- a/DaaS/Configuration/Settings.cs
+++ b/DaaS/Configuration/Settings.cs
@@ -28,6 +28,7 @@ namespace DaaS.Configuration
         const string DefaultHostNameSandboxProperty = "SANDBOX_FUNCTION_RESOURCE_ID";
         const string DaasStorageSasUri = "WEBSITE_DAAS_STORAGE_SASURI";
         const string DaasStorageConnectionString = "WEBSITE_DAAS_STORAGE_CONNECTIONSTRING";
+        const string SandboxPropertyStorageAccountResourceId = "WEBSITE_DAAS_STORAGE_RESOURCEID";
         const string ContainerName = "memorydumps";
 
         private string _diagnosticToolsPath;
@@ -87,6 +88,29 @@ namespace DaaS.Configuration
                 }
 
                 string envvar = Environment.GetEnvironmentVariable(DaasStorageSasUri);
+                if (!string.IsNullOrWhiteSpace(envvar))
+                {
+                    return envvar;
+                }
+
+                return string.Empty;
+            }
+        }
+
+        internal string AccountResourceId
+        {
+            get
+            {
+                if (IsSandBoxAvailable())
+                {
+                    string resourceId = GetSandboxProperty(SandboxPropertyStorageAccountResourceId);
+                    if (!string.IsNullOrWhiteSpace(resourceId))
+                    {
+                        return resourceId;
+                    }
+                }
+
+                string envvar = Environment.GetEnvironmentVariable(SandboxPropertyStorageAccountResourceId);
                 if (!string.IsNullOrWhiteSpace(envvar))
                 {
                     return envvar;

--- a/DaaS/Properties/AssemblyInfo.cs
+++ b/DaaS/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DaaSTests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DiagnosticAnalysisLauncher")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("cda96362-3f19-4fe7-a33f-d3b15f307551")]


### PR DESCRIPTION
* I also refactored `DiagnosticAnalysisLauncher` to depend on `Daas.Configuration` so we don't have to rewrite code for when we need to get the resource id or the SAS URL.
* `E2eTests.SubmitMemoryDumpSession` was updated to perform some basic sanity checks on the ResultsViewer html file.