### PR TITLE
Update DiagAnalysis CLI (17.8.1080801) & ResultsViewer (1.0.2410.213)

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.OneCore.x64" GeneratePathProperty="true">
-      <Version>17.7.1050401</Version>
+      <Version>17.8.1080801</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -65,7 +65,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.7.1050401</Version>
+      <Version>17.8.1080801</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DiagnosticAnalysisLauncher/Models/DiagnosticAnalysis.cs
+++ b/DiagnosticAnalysisLauncher/Models/DiagnosticAnalysis.cs
@@ -51,6 +51,7 @@ namespace DiagnosticAnalysisLauncher
         public string shortDescription { get; set; }
         public string severity { get; set; }
         public string errorCode { get; set; }
+        public IDictionary<string, object> stats { get; set; }
     }
 
     public class Detail

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -454,7 +454,7 @@
     </Content>
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2315.170\content\client\**\*" Exclude="**\*.js.map">
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2410.213\content\client\**\*" Exclude="**\*.js.map">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -42,7 +42,7 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net48" />
-  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2315.170" targetFramework="net48" />
+  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2410.213" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />


### PR DESCRIPTION
Some of the most important changes in the CLI include:
 * Perf statistics in the output. I've updated `DiagnosticAnalysis.cs` to include them in the telemetry - for now that's just analysis and interpretation time, but we plan to extend that in the future.
 * There's a 9-minute timeout after which analyses that haven't finished are terminated.
 * Analyses include decompile user code and ResultsViewer was updated to render it.