### PR TITLE
Dev/clguiman/update/cli

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.OneCore.x64" GeneratePathProperty="true">
-      <Version>17.8.1080801</Version>
+      <Version>17.8.1092201</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -65,7 +65,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.8.1080801</Version>
+      <Version>17.8.1092201</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DiagnosticAnalysisLauncher/Models/DiagnosticAnalysis.cs
+++ b/DiagnosticAnalysisLauncher/Models/DiagnosticAnalysis.cs
@@ -12,6 +12,9 @@ namespace DiagnosticAnalysisLauncher
 {
     public class DiagnosticAnalysis
     {
+        [JsonProperty("cliSummary", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public CLISummary CliSummary { get; set; }
+
         public Interpretedresult[] interpretedResults { get; set; }
 
         public Assets assets { get; set; }
@@ -52,6 +55,12 @@ namespace DiagnosticAnalysisLauncher
         public string severity { get; set; }
         public string errorCode { get; set; }
         public IDictionary<string, object> stats { get; set; }
+    }
+
+    public class CLISummary
+    {
+        [JsonProperty("version", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public string Version { get; set; }
     }
 
     public class Detail

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -454,7 +454,7 @@
     </Content>
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2410.213\content\client\**\*" Exclude="**\*.js.map">
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2459.227\content\client\**\*" Exclude="**\*.js.map">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -42,7 +42,7 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net48" />
-  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2410.213" targetFramework="net48" />
+  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2459.227" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />


### PR DESCRIPTION
* Update DiagnosticAnalysis CLI to `17.8.1092201`
     Main updates:
     - Output size is significantly smaller.
     - Memory usage telemetry.
     - New memory analyzers for duplicate strings, sparse arrays & event handlers.
* Update ResultsViewer to `1.0.2459.227`
* Include the CLI version in the analysis telemetry.