### PR TITLE
Update the DiagnosticAnalysis CLI package names and update the CLI(17.10.1121402) & ResultsViewer(1.02558.245)

### DIFF
--- a/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
+++ b/DiagnosticAnalysisLauncher/DiagnosticAnalysisLauncher.csproj
@@ -55,8 +55,8 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.OneCore.x64" GeneratePathProperty="true">
-      <Version>17.8.1092201</Version>
+    <PackageReference Include="Microsoft.VisualStudio.MemoryDumpAnalysis.OneCore.x64.SelfContained" GeneratePathProperty="true">
+      <Version>17.10.1121402</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -64,16 +64,16 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticAnalysis.Windows" GeneratePathProperty="true">
-      <Version>17.8.1092201</Version>
+    <PackageReference Include="Microsoft.VisualStudio.MemoryDumpAnalysis.Windows.SelfContained" GeneratePathProperty="true">
+      <Version>17.10.1121402</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(PkgMicrosoft_VisualStudio_DiagnosticAnalysis_Windows)\content\**\*">
+    <Content Include="$(PkgMicrosoft_VisualStudio_MemoryDumpAnalysis_Windows_SelfContained)\content\**\*">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(PkgMicrosoft_VisualStudio_DiagnosticAnalysis_OneCore_x64)\content\**\*">
+    <Content Include="$(PkgMicrosoft_VisualStudio_MemoryDumpAnalysis_OneCore_x64_SelfContained)\content\**\*">
       <Link>DiagnosticAnalysis\DiagnosticAnalysis_OneCore_x64\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/DiagnosticsExtension.csproj
+++ b/DiagnosticsExtension/DiagnosticsExtension.csproj
@@ -454,7 +454,7 @@
     </Content>
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
-    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2459.227\content\client\**\*" Exclude="**\*.js.map">
+    <Content Include="..\packages\Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer.1.0.2558.245\content\client\**\*" Exclude="**\*.js.map">
       <Link>DiagnosticAnalysis\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DiagnosticsExtension/packages.config
+++ b/DiagnosticsExtension/packages.config
@@ -42,7 +42,7 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net48" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net48" />
-  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2459.227" targetFramework="net48" />
+  <package id="Microsoft.VisualStudio.DiagnosticAnalysis.ResultsViewer" version="1.0.2558.245" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />


### PR DESCRIPTION
The Memory Dump Analysis CLIs now get published under a different name. This PR updates the package names and updates the viewer package version to keep compatibility (the new CLI output is not compatible with older versions of the viewer).
